### PR TITLE
refactor: improve semantic accessibility across header, lists, auth forms, and action controls

### DIFF
--- a/src/features/auth/components/ResetPasswordContentView.tsx
+++ b/src/features/auth/components/ResetPasswordContentView.tsx
@@ -22,7 +22,7 @@ export const ResetPasswordContentView = memo(function ResetPasswordContentView({
 }: ResetPasswordContentViewProps) {
   return (
     <main className="m-auto mt-20">
-      <h2 className="title2 text-center" id="reset-password">
+      <h2 className="title2 text-center" id="reset-password-heading">
         비밀번호 재설정
       </h2>
       <p className="mt-5 text-center">

--- a/src/features/auth/components/ResetPasswordFormView.tsx
+++ b/src/features/auth/components/ResetPasswordFormView.tsx
@@ -26,23 +26,26 @@ export const ResetPasswordFormView = memo(function ResetPasswordFormView({
   isPending,
 }: ResetPasswordFormViewProps) {
   return (
-    <form action={onSubmit} className="mt-12 w-96" aria-label="비밀번호 재설정 폼">
-      <Input
-        onChange={(e) => onEmailChange(e.target.value)}
-        value={email}
-        name="email"
-        type="email"
-        required
-        className="border-b"
-        placeholder="이메일 입력"
-        aria-label="이메일 입력"
-      />
-      <Button
-        type="submit"
-        isPending={isPending}
-        className="mt-5 w-full bg-green-400 text-white"
-        aria-label="비밀번호 재설정 링크 메일 발송"
-      >
+    <form action={onSubmit} className="mt-12 w-96" aria-labelledby="reset-password-heading">
+      <fieldset className="flex flex-col gap-4">
+        <legend className="sr-only">비밀번호 재설정 정보 입력</legend>
+        <div>
+          <label htmlFor="reset-password-email" className="sr-only">
+            이메일 입력
+          </label>
+          <Input
+            id="reset-password-email"
+            onChange={(e) => onEmailChange(e.target.value)}
+            value={email}
+            name="email"
+            type="email"
+            required
+            className="border-b"
+            placeholder="이메일 입력"
+          />
+        </div>
+      </fieldset>
+      <Button type="submit" isPending={isPending} className="mt-5 w-full bg-green-400 text-white">
         비밀번호 재설정하기
       </Button>
     </form>

--- a/src/features/auth/components/SignInContentView.tsx
+++ b/src/features/auth/components/SignInContentView.tsx
@@ -14,22 +14,20 @@ export const SignInContentView = memo(function SignInContentView() {
       <h2 className="title2 mt-20 text-center" id="login-heading">
         로그인
       </h2>
-      <div className="mt-10 w-96" aria-labelledby="login-heading">
+      <section className="mt-10 w-96" aria-labelledby="login-heading">
         <Form />
-        <div className="subtitle mt-10 flex items-center justify-center gap-3">
-          <Link
-            className="flex-1 text-end"
-            href="/auth/reset-pw"
-            aria-label="비밀번호 재설정 페이지로 이동"
-          >
-            비밀번호 찾기
-          </Link>
-          <p>|</p>
-          <Link className="flex-1" href="/auth/sign-up" aria-label="회원가입 페이지로 이동">
-            회원가입
-          </Link>
-        </div>
-      </div>
+        <nav className="subtitle mt-10" aria-label="로그인 관련 링크">
+          <ul className="flex items-center justify-center gap-3">
+            <li className="flex-1 text-end">
+              <Link href="/auth/reset-pw">비밀번호 찾기</Link>
+            </li>
+            <li aria-hidden="true">|</li>
+            <li className="flex-1">
+              <Link href="/auth/sign-up">회원가입</Link>
+            </li>
+          </ul>
+        </nav>
+      </section>
     </>
   );
 });

--- a/src/features/auth/components/WithdrawContentView.tsx
+++ b/src/features/auth/components/WithdrawContentView.tsx
@@ -24,7 +24,7 @@ export const WithdrawContentView = memo(function WithdrawContentView({
 }: WithdrawContentViewProps) {
   return (
     <main className="m-auto mt-20">
-      <h2 className="title2 text-center" id="reset-password-heading">
+      <h2 className="title2 text-center" id="withdraw-heading">
         회원 탈퇴
       </h2>
       <p className="mt-5 text-center">정말 탈퇴하시겠습니까? 회원 정보를 복구할 수 없습니다.</p>

--- a/src/features/auth/components/WithdrawFormView.tsx
+++ b/src/features/auth/components/WithdrawFormView.tsx
@@ -32,29 +32,38 @@ export const WithdrawFormView = memo(function WithdrawFormView({
     <form
       className="mt-15 flex w-96 flex-col gap-4"
       onSubmit={onSubmit}
-      aria-labelledby="reset-password-heading"
+      aria-labelledby="withdraw-heading"
     >
-      <Input
-        type="email"
-        value={email}
-        onChange={(e) => onEmailChange(e.target.value)}
-        required
-        placeholder="이메일 입력"
-        aria-label="이메일 입력"
-      />
-      <Input
-        type="password"
-        value={password}
-        onChange={(e) => onPasswordChange(e.target.value)}
-        required
-        placeholder="비밀번호 입력"
-        aria-label="비밀번호 입력"
-      />
-      <Button
-        type="submit"
-        className="mt-5 w-full bg-green-400 text-white"
-        aria-label="회원 탈퇴하기"
-      >
+      <fieldset className="flex flex-col gap-4">
+        <legend className="sr-only">회원 탈퇴 확인 정보</legend>
+        <div>
+          <label htmlFor="withdraw-email" className="sr-only">
+            이메일 입력
+          </label>
+          <Input
+            id="withdraw-email"
+            type="email"
+            value={email}
+            onChange={(e) => onEmailChange(e.target.value)}
+            required
+            placeholder="이메일 입력"
+          />
+        </div>
+        <div>
+          <label htmlFor="withdraw-password" className="sr-only">
+            비밀번호 입력
+          </label>
+          <Input
+            id="withdraw-password"
+            type="password"
+            value={password}
+            onChange={(e) => onPasswordChange(e.target.value)}
+            required
+            placeholder="비밀번호 입력"
+          />
+        </div>
+      </fieldset>
+      <Button type="submit" className="mt-5 w-full bg-green-400 text-white">
         회원 탈퇴하기
       </Button>
     </form>

--- a/src/features/auth/components/sign-in/form.tsx
+++ b/src/features/auth/components/sign-in/form.tsx
@@ -50,37 +50,48 @@ const Form = () => {
         autoComplete="on"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <div>
-          <label htmlFor="email">이메일</label>
-          <span className="ml-3 text-green-500">{errors.email?.message}</span>
-          <div className="relative mt-2">
-            <SVGIcon name="EmailIcon" className="absolute top-3 left-3" />
-            <Input
-              id="email"
-              type="email"
-              {...register("email")}
-              required
-              autoComplete="email"
-              className="pl-10"
-            />
+        <fieldset className="flex flex-col gap-6">
+          <legend className="sr-only">이메일 로그인</legend>
+          <div>
+            <label htmlFor="email">이메일</label>
+            {errors.email?.message && (
+              <output htmlFor="email" className="ml-3 text-green-500">
+                {errors.email.message}
+              </output>
+            )}
+            <div className="relative mt-2">
+              <SVGIcon name="EmailIcon" className="absolute top-3 left-3" />
+              <Input
+                id="email"
+                type="email"
+                {...register("email")}
+                required
+                autoComplete="email"
+                className="pl-10"
+              />
+            </div>
           </div>
-        </div>
 
-        <div>
-          <label htmlFor="password">비밀번호</label>
-          <span className="ml-3 text-green-500">{errors.password?.message}</span>
-          <div className="relative mt-2">
-            <SVGIcon name="PasswordIcon" className="absolute top-3 left-3" />
-            <Input
-              id="password"
-              type="password"
-              {...register("password")}
-              required
-              autoComplete="password"
-              className="pl-10"
-            />
+          <div>
+            <label htmlFor="password">비밀번호</label>
+            {errors.password?.message && (
+              <output htmlFor="password" className="ml-3 text-green-500">
+                {errors.password.message}
+              </output>
+            )}
+            <div className="relative mt-2">
+              <SVGIcon name="PasswordIcon" className="absolute top-3 left-3" />
+              <Input
+                id="password"
+                type="password"
+                {...register("password")}
+                required
+                autoComplete="password"
+                className="pl-10"
+              />
+            </div>
           </div>
-        </div>
+        </fieldset>
         <Button type="submit" disabled={!isValid} className="mt-5 w-full bg-green-400 text-white">
           로그인
         </Button>
@@ -88,11 +99,11 @@ const Form = () => {
 
       <div className="relative mt-6 flex justify-center">
         <button
-          type="submit"
+          type="button"
           onClick={handleGoogleLogin}
           className="flex w-full items-center justify-center gap-2 rounded-full border border-gray-4 px-4 py-3"
         >
-          <Image src={"/google.svg"} alt="icon" width="20" height="20" priority={true} />
+          <Image src="/google.svg" alt="Google" width="20" height="20" priority={true} />
           <span>Google로 계속하기</span>
         </button>
       </div>

--- a/src/features/auth/components/sign-up/form.tsx
+++ b/src/features/auth/components/sign-up/form.tsx
@@ -50,15 +50,20 @@ export default function Form() {
   }, [result, router, reset]);
 
   return (
-    <>
-      <form
-        className="subtitle flex flex-col gap-6"
-        autoComplete="on"
-        onSubmit={handleSubmit(onSubmit)}
-      >
+    <form
+      className="subtitle flex flex-col gap-6"
+      autoComplete="on"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <fieldset className="flex flex-col gap-6">
+        <legend className="sr-only">회원가입 정보 입력</legend>
         <div>
           <label htmlFor="displayName">닉네임</label>
-          <span className="ml-3 text-green-500">{errors.displayName?.message}</span>
+          {errors.displayName?.message && (
+            <output htmlFor="displayName" className="ml-3 text-green-500">
+              {errors.displayName.message}
+            </output>
+          )}
           <Input
             id="displayName"
             type="text"
@@ -70,7 +75,11 @@ export default function Form() {
 
         <div>
           <label htmlFor="email">이메일</label>
-          <span className="ml-3 text-green-500">{errors.email?.message}</span>
+          {errors.email?.message && (
+            <output htmlFor="email" className="ml-3 text-green-500">
+              {errors.email.message}
+            </output>
+          )}
           <Input
             id="email"
             type="email"
@@ -82,7 +91,11 @@ export default function Form() {
 
         <div>
           <label htmlFor="password">비밀번호</label>
-          <span className="ml-3 text-green-500">{errors.password?.message}</span>
+          {errors.password?.message && (
+            <output htmlFor="password" className="ml-3 text-green-500">
+              {errors.password.message}
+            </output>
+          )}
           <div className="relative mt-2">
             <Input
               id="password"
@@ -96,7 +109,11 @@ export default function Form() {
 
         <div>
           <label htmlFor="confirmPassword">비밀번호 재확인</label>
-          <span className="ml-3 text-green-500">{errors.confirmPassword?.message}</span>
+          {errors.confirmPassword?.message && (
+            <output htmlFor="confirmPassword" className="ml-3 text-green-500">
+              {errors.confirmPassword.message}
+            </output>
+          )}
           <Input
             id="confirmPassword"
             type="password"
@@ -105,17 +122,17 @@ export default function Form() {
             className="mt-2"
           />
         </div>
-        <div>
-          <Button
-            type="submit"
-            disabled={!isValid}
-            isPending={isPending}
-            className="mt-5 w-full bg-green-400 text-white"
-          >
-            가입하기
-          </Button>
-        </div>
-      </form>
-    </>
+      </fieldset>
+      <div>
+        <Button
+          type="submit"
+          disabled={!isValid}
+          isPending={isPending}
+          className="mt-5 w-full bg-green-400 text-white"
+        >
+          가입하기
+        </Button>
+      </div>
+    </form>
   );
 }

--- a/src/features/shared/layout/header/header.tsx
+++ b/src/features/shared/layout/header/header.tsx
@@ -39,7 +39,7 @@ export default function Header() {
 
   if (pathName.includes("preview")) {
     return (
-      <nav className="fixed z-10 flex w-screen flex-col items-center text-nowrap bg-surface drop-shadow backdrop-blur-sm">
+      <header className="fixed z-10 flex w-screen flex-col items-center text-nowrap bg-surface drop-shadow backdrop-blur-sm">
         <div className="flex h-20 w-full items-center justify-between px-8 2xl:w-350 2xl:px-0">
           <h1>
             <Link href="/">
@@ -50,19 +50,22 @@ export default function Header() {
             미리보기 종료
           </Button>
         </div>
-      </nav>
+      </header>
     );
   }
 
   return (
-    <nav className="fixed z-10 flex w-screen flex-col items-center text-nowrap bg-surface drop-shadow backdrop-blur-sm dark:bg-muted">
-      <div className="flex h-20 w-full items-center justify-between gap-2 px-8 md:grid md:grid-cols-3 md:gap-8 2xl:w-350 2xl:px-0">
+    <header className="fixed z-10 flex w-screen flex-col items-center text-nowrap bg-surface drop-shadow backdrop-blur-sm dark:bg-muted">
+      <nav
+        className="flex h-20 w-full items-center justify-between gap-2 px-8 md:grid md:grid-cols-3 md:gap-8 2xl:w-350 2xl:px-0"
+        aria-label="주요 메뉴"
+      >
         <NavLeft handleMouseOver={handleMouseOver} handleMouseLeave={handleMouseLeave} />
         <NavSearch />
         <NavRight />
-      </div>
+      </nav>
       {isSubMenuOpen && (
-        <ul
+        <menu
           className="flex w-full flex-1 gap-8 overflow-y-auto text-nowrap px-8 pb-6 2xl:w-350 2xl:px-0"
           onMouseOver={() => handleMouseOver(hoveredCategory)}
           onFocus={() => handleMouseOver(hoveredCategory)}
@@ -74,8 +77,8 @@ export default function Header() {
               <Link href={`/${hoveredCategory}?cat=${value}`}>{key}</Link>
             </li>
           ))}
-        </ul>
+        </menu>
       )}
-    </nav>
+    </header>
   );
 }

--- a/src/features/shared/layout/header/navSearch.tsx
+++ b/src/features/shared/layout/header/navSearch.tsx
@@ -14,29 +14,31 @@ export default function NavSearch() {
     router.push(`/search?query=${encodeURIComponent(param)}`);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      handleSearch();
-    }
-  };
-
   return (
-    <div className="relative ml-3 w-full flex-1">
+    <form
+      className="relative ml-3 w-full flex-1"
+      onSubmit={(e) => {
+        e.preventDefault();
+        handleSearch();
+      }}
+    >
+      <label htmlFor="global-search" className="sr-only">
+        통합 검색
+      </label>
       <Input
+        id="global-search"
         className="subtitle w-full bg-gray-300/20 pr-10 focus:ring-2 focus:ring-green-300"
-        type="text"
+        type="search"
         placeholder="관심사를 찾아보세요!"
         value={param}
         onChange={(e) => setParam(e.target.value)}
-        onKeyDown={handleKeyDown}
       />
       <button
-        type="button"
+        type="submit"
         className="-translate-y-1/2 absolute top-1/2 right-3 transform cursor-pointer"
-        onClick={handleSearch}
       >
         <SVGIcon name="SearchIcon" className="text-green-400" />
       </button>
-    </div>
+    </form>
   );
 }

--- a/src/features/shared/ui/actionButtons.tsx
+++ b/src/features/shared/ui/actionButtons.tsx
@@ -26,10 +26,37 @@ export default function ActionButtons() {
   }, []);
 
   return (
-    <div className="mt-10 flex gap-5 font-bold">
-      <SVGIcon name="ShareIcon" onClick={handleShare} className="cursor-pointer" />
-      <SVGIcon name="BookmarkIcon" onClick={handleBookmark} className="cursor-pointer" />
-      <SVGIcon name="ReportIcon" onClick={handleReport} className="cursor-pointer" />
-    </div>
+    <menu className="mt-10 flex gap-5 font-bold">
+      <li>
+        <button
+          type="button"
+          onClick={handleShare}
+          className="cursor-pointer"
+          aria-label="공유하기"
+        >
+          <SVGIcon name="ShareIcon" />
+        </button>
+      </li>
+      <li>
+        <button
+          type="button"
+          onClick={handleBookmark}
+          className="cursor-pointer"
+          aria-label="북마크하기"
+        >
+          <SVGIcon name="BookmarkIcon" />
+        </button>
+      </li>
+      <li>
+        <button
+          type="button"
+          onClick={handleReport}
+          className="cursor-pointer"
+          aria-label="신고하기"
+        >
+          <SVGIcon name="ReportIcon" />
+        </button>
+      </li>
+    </menu>
   );
 }

--- a/src/features/shared/ui/sectionHeader.tsx
+++ b/src/features/shared/ui/sectionHeader.tsx
@@ -4,21 +4,25 @@ interface SectionHeaderProps {
   title: string;
   linkHref?: string;
   linkLabel?: string;
+  headingId?: string;
 }
 
 export default function SectionHeader({
   title,
   linkHref,
   linkLabel = "모든 설문 보기 →",
+  headingId,
 }: SectionHeaderProps) {
   return (
-    <div className="mb-6 flex items-end justify-between">
-      <h2 className="title2">{title}</h2>
+    <header className="mb-6 flex items-end justify-between">
+      <h2 id={headingId} className="title2">
+        {title}
+      </h2>
       {linkHref && linkLabel && (
         <Link href={linkHref} className="caption">
           {linkLabel}
         </Link>
       )}
-    </div>
+    </header>
   );
 }

--- a/src/features/survey/list/components/main/ClosingRecruits.tsx
+++ b/src/features/survey/list/components/main/ClosingRecruits.tsx
@@ -9,9 +9,16 @@ const ClosingRecruits = async () => {
   const closingRecruits = await fetchFormList("recruit", "endingSoon");
 
   return (
-    <section className="flex w-full justify-center bg-surface px-4 py-16 drop-shadow-sm md:px-8 2xl:px-0 dark:bg-muted">
+    <section
+      className="flex w-full justify-center bg-surface px-4 py-16 drop-shadow-sm md:px-8 2xl:px-0 dark:bg-muted"
+      aria-labelledby="closing-recruits-heading"
+    >
       <div className="w-full 2xl:w-350">
-        <SectionHeader title="곧 마감되는 모집 공고를 살펴보세요" linkHref="/recruit?cat=all" />
+        <SectionHeader
+          title="곧 마감되는 모집 공고를 살펴보세요"
+          linkHref="/recruit?cat=all"
+          headingId="closing-recruits-heading"
+        />
         <ul className="grid gap-4 md:grid-cols-3 md:gap-8">
           {closingRecruits.length > 0
             ? closingRecruits.map((item) => (

--- a/src/features/survey/list/components/main/LatestComments.tsx
+++ b/src/features/survey/list/components/main/LatestComments.tsx
@@ -14,7 +14,11 @@ const LatestComments = async () => {
       aria-labelledby="latest-comments-heading"
     >
       <div className="w-full 2xl:w-350">
-        <SectionHeader title="최신 댓글이 달린 설문조사를 살펴보세요" linkHref="/survey?cat=all" />
+        <SectionHeader
+          title="최신 댓글이 달린 설문조사를 살펴보세요"
+          linkHref="/survey?cat=all"
+          headingId="latest-comments-heading"
+        />
         <ul className="mb-8 grid gap-4 md:grid-cols-2 md:gap-8">
           {latestComments && latestComments.length > 0
             ? latestComments.map((item) => <CommentItem key={item.id} item={item} />)

--- a/src/features/survey/list/components/main/RecentPopularSurveys.tsx
+++ b/src/features/survey/list/components/main/RecentPopularSurveys.tsx
@@ -16,7 +16,7 @@ const FormListSection = async ({ title, link, sortType }: FormListSectionProps) 
 
   return (
     <section className="flex-1" aria-labelledby={`${sortType}-title`}>
-      <SectionHeader title={title} linkHref={link} />
+      <SectionHeader title={title} linkHref={link} headingId={`${sortType}-title`} />
       <ul className="grid grid-cols-2 gap-4 md:gap-8">
         {forms.length > 0
           ? forms.map((item) => <FormCardItem type="survey" key={item.id} item={item} />)


### PR DESCRIPTION
### Motivation
- Improve overall web accessibility by prioritizing semantic HTML over ARIA where possible. 
- Make interactive elements keyboard-accessible and ensure headings and regions are properly linked for screen readers. 
- Reduce unnecessary ARIA usage and expose validation messages in an accessible manner. 

### Description
- Reworked global header to use a proper `header` containing a `nav` and replaced the floating sublist with a semantic `menu` element, and updated the search area to a form with a labeled `search` input (`src/features/shared/layout/header/header.tsx`, `src/features/shared/layout/header/navSearch.tsx`).
- Converted the shared section header component to use a `header` wrapper and added a `headingId` prop so sections can supply `aria-labelledby` IDs (`src/features/shared/ui/sectionHeader.tsx`).
- Wired `aria-labelledby` on list sections and injected matching heading IDs for `LatestComments`, `ClosingRecruits`, and `RecentPopularSurveys` (`src/features/survey/list/components/main/*`).
- Applied semantic form markup to authentication flows: added `fieldset`/`legend`, replaced inline error text with `output`, added explicit `label` / `id` pairs, and normalized heading IDs for reset/withdraw flows (`src/features/auth/components/*`).
- Replaced clickable SVGs with real `button` elements inside a `menu` for action icons to ensure keyboard/focus support and kept minimal `aria-label`s for icon-only buttons (`src/features/shared/ui/actionButtons.tsx`).
- Minor input/markup cleanups: changed search input `type` to `search`, made Google auth button `type="button"`, and removed redundant ARIA where native semantics suffice.

### Testing
- Ran `yarn biome check` / formatting on modified files and verified there are no lint/format errors for the touched files (checks passed). 
- Started the dev server and visited `/auth/sign-in` to validate rendering and interactions; a Playwright screenshot was captured to confirm UI render. 
- Functional verification was limited by environment: the app attempted to initialize Firebase and raised `auth/invalid-api-key`, so end-to-end auth flows could not be fully exercised during this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b2c5a21b08327a186697be79c34a6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 폼 요소의 구조를 개선하여 더 나은 접근성을 제공합니다.
  * 의미론적 HTML 마크업(header, nav, section, fieldset, form 등)으로 업데이트했습니다.
  * 오류 메시지의 조건부 렌더링을 구현하여 사용자 경험을 개선했습니다.
  * ARIA 레이블과 속성을 추가하여 스크린 리더 호환성을 높였습니다.
  * 네비게이션 및 액션 버튼의 시맨틱 마크업을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->